### PR TITLE
Vim: Initial integration of TextLint in quickfix window

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,9 +26,11 @@ TextLint is a
 TextLint is currently accessible through:
 
 - [An Emacs plugin](#emacs-installing)
+- [A Vim plugin](#vim-installing)
 - [A TextMate plugin](#textmate-installing)
 - [A web interface](http://textlint.lukas-renggli.ch/)
 - [A Smalltalk IDE](http://scg.unibe.ch/research/textlint)
+
 
 # Setup instructions for Emacs <a name="emacs-installing"></a>
 
@@ -49,7 +51,7 @@ Now you can [use TextLint](#emacs-using).
 ## Without el-get <a name="emacs-no-el-get"></a>
 
 If you do not use el-get,
-[download the project archive file][https://github.com/DamienCassou/textlint/zipball/master] from the [github project](https://github.com/DamienCassou/textlint), unzip, update your load-path, and load "textlint.el".
+[download the project archive file][zipball] from the [github project](https://github.com/DamienCassou/textlint), unzip, update your load-path, and load "textlint.el".
 
 You then have to customize the variables in the textlint group using
 `M-x customize-group RET textlint RET`. You at least need to configure
@@ -63,11 +65,31 @@ You can now visit a text file and type `M-x textlint-run RET`. When
 you see "Compilation finished", you can start using `` C-x ` `` to
 visit the next error message and move to the text that caused it.
 
+
+# Setup instructions for Vim <a name="vim-installing"></a>
+
+The recommended installation procedure is to use [pathogen][] or [Vundle][].
+
+For [pathogen][], just unzip [the textlint archive][zipball] or checkout the TextLint repository under `~/.vim/bundle`.
+
+For [Vundle][], add this line to your `.vimrc`:
+
+    Bundle 'DamienCassou/textlint'
+
+[pathogen]: https://github.com/tpope/vim-pathogen "Pathogen.vim, manage your runtimepath"
+[vundle]: https://github.com/gmarik/vundle "Vundle, the plug-in manager for Vim"
+
+## Using TextLint under Vim <a name="vim-using"></a>
+
+To invoke TextLint, use the `:TextLint` command from your text buffer. For convenience, there is a predefined shortcut: `<leader>tl`. Once TextLint has finished, Vim's quickfix window will open; you can then navigate between TextLint suggestions with the normal `:cn` and `:cp` commands. Consult `:help quickfix` for more details.
+
+
 # Setup instructions for TextMate <a name="textmate-installing"></a>
 
 Double click on "TextLint.tmbundle" to install TextLint. Open a LaTeX
 or plain text file and press `Ctrl+Shift+V` to run TextLint. Alternatively
 select "Bundles > TextLint > RunText Lint" from the menu.
+
 
 # Support <a name="support"></a>
 
@@ -83,3 +105,6 @@ If you want to change the TextLint engine or just have a look at it,
 get it from the [SCG website](http://scg.unibe.ch/research/textlint).
 Please propose patches by email
 [to the developers](http://www.squeaksource.com/textlint.html).
+
+[zipball]: https://github.com/DamienCassou/textlint/zipball/master "Zip snapshot of TextLint"
+

--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ ruled-based tool to check for common style errors in natural language.
 TextLint provides a structural model of written text and an extensible
 rule-based checking mechanism.
 
-TextLint implements various stylistic rules that his authors collected
+TextLint implements various stylistic rules that its authors collected
 over the years, and that are described in
 
 - The Elements of Style, by William Strunk Jr. and E. B. White

--- a/doc/textlint.txt
+++ b/doc/textlint.txt
@@ -1,0 +1,54 @@
+*textlint.txt* Writing style checker
+                                                     *textlint* *textlint.vim*
+
+
+TextLint is a ruled-based tool to check for common writing style errors in
+natural language. This plugin integrates it with Vim's quickfix feature, to
+conveniently navigate between style suggestions in your text.
+
+
+USAGE                                                         *textlint-usage*
+
+Run TextLint on the current buffer by issuing the command |:TextLint|. When
+TextLint is finished, the |quickfix| window will open, with a list of the
+stylistic rule matches it found. You can then navigate from the list to the
+text using |:cn| and |:cp|; see |quickfix| for details.
+
+Commands ~
+
+:TextLint                                                         *:TextLint*
+    Runs TextLint on the file of the current buffer, displaying results in the
+    |quickfix| window.
+
+Mappings ~
+
+<leader>tl
+    A shortcut for |:TextLint|.
+
+
+INSTALLATION                                           *textlint-installation*
+
+The nicest way to install |textlint.vim| is via either of:
+- Pathogen: https://github.com/tpope/vim-pathogen
+- Vundle: https://github.com/gmarik/vundle
+
+Besides the Vim integration files, the |textlint.vim| distribution contains
+the TextLint tool itself as well as integration files for other editors. The
+Vim plugin expects to find TextLint relative to where it's installed, so pay
+attention to this if you really want to install it the traditional way. You've
+been warned.
+
+
+ABOUT                                                         *textlint-about*
+
+TextLint implements various stylistic rules that its authors collected over
+the years, and that are described in:
+- "The Elements of Style", by William Strunk Jr. and E. B. White
+- "On Writing Well", by William Zinsser
+
+ Home page: http://scg.unibe.ch/research/textlint
+Online app: http://textlint.lukas-renggli.ch
+    Github: https://github.com/DamienCassou/textlint
+
+
+ vim:tw=78:ft=help:norl:

--- a/plugin/textlint.vim
+++ b/plugin/textlint.vim
@@ -1,0 +1,47 @@
+" TODO
+" - locate VM, image, launcher script
+" - function to invoke textlint
+" - adding / loading into the quickfix list
+" - highlighting
+" - toggling, options
+
+"if exists('g:loaded_textlint') || &compatible
+    "finish
+"endif
+"let g:loaded_textlint = 1
+
+if !exists('g:textlint_highlight')
+    let g:textlint_highlight = 1
+endif
+
+command! -nargs=? -complete=file TextLint :call s:TextLint(<f-args>)
+nnoremap <leader>tl :TextLint
+
+let s:installDir = expand('<sfile>:p:h:h')
+if has('win32')
+    let s:vm = "/Windows32/pharo.exe"
+elseif has('macunix')
+    let s:vm = "/TextLint.tmbundle/Support/TextLint.app/Contents/MacOS/Croquet"
+elseif has('unix')
+    let s:vm = "/Linux32/pharo"
+endif
+let s:vm = s:installDir . s:vm
+let s:launcher = s:installDir . "/textlint.bash"
+let s:image = s:installDir . "/TextLint.tmbundle/Support/TextLint.image"
+
+function! s:cmd(file)
+    return s:launcher . ' ' . a:file . ' ' . s:vm . ' ' . s:image
+endfunction
+
+function! s:TextLint(...)
+    setlocal errorformat=%f:%l.%c-%*[0-9.]:\ %m
+    setlocal errorformat+=%+G\	%.%#
+    setlocal errorformat+=%-G%.%#
+
+    let l:file = a:0 == 0 ? expand('%:p') : getcwd() . '/' . a:1
+
+    echo 'Running TextLint on ' . l:file . '...'
+    cexpr system(s:cmd(l:file))
+    copen
+endfunction
+


### PR DESCRIPTION
I'm working on a nicer version, but this works fine.

To use it in Vim, the best is to use something like [pathogen](https://github.com/tpope/vim-pathogen) and checkout the textlint repo in `~/.vim/bundle`. Then invoke `:TextLint` from your text buffer. This uses Vim's `quickfix` feature, with the standard `:cn` commands to navigate between errors.
